### PR TITLE
Add accentInsensitive option to dataset filter

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <link href="../lib/bootstrap/css/bootstrap.css" rel="stylesheet" media="screen">
         <link href="dw.css" rel="stylesheet">
 
@@ -491,6 +492,7 @@
                             <li><code>columns</code> <i>(array of strings or single string)</i>: Columns on which to filter (defaults to all columns)</li>
                             <li><code>column</code> <i>(single string)</i>: Single column on which to filter (defaults to all columns) (note: if both <code>columns</code> and <code>column</code> are defined, the latter will be used)</li>
                             <li><code>matchAll</code> <i>(boolean)</i>: If this flag is set to <code>true</code> then all columns provided must match the filter for the row to stay visible. By default, if any of the columns match the row will stay visible</li>
+                            <li><code>accentInsensitive</code> <i>(boolean)</i>: If this flag is set to <code>true</code> then characters with accent marks will be treated as normal ascii character (e.g., appl&#233; matches both appl&#233; and apple).</li>
                             <li><code>regex</code> <i>(string or RegExp)</i>: Columns must match this regular expression (if a string is provided it will be converted to a RegExp)</li>
                             <li><code>!regex</code> <i>(string or RegExp)</i>: Columns must <b>not</b> match this regular expression (if a string is provided it will be converted to a RegExp)</li>
                             <li><code>eq</code> <i>(value)</i>: Columns must equal (==) this value</li>

--- a/test/dw-local.js
+++ b/test/dw-local.js
@@ -541,6 +541,88 @@ QUnit.test("apply filter (complex, single filter, multiple columns)", function (
     }).finish(done);
 });
 
+QUnit.test("apply filter (complex, single filter, multiple columns, accent insensitive)", function (assert) {
+    assert.expect(1);
+
+    var done = assert.async();
+
+    var dataset = [
+        [ "column_a", "column_b", "column_c" ],
+
+        [ "âpplé",      "violin",    "music" ],
+        [ "cat",        "tissue",      "dog" ],
+        [ "banana",      "piano",      "gum" ],
+        [ "gummy",       "power",    "apple" ]
+    ];
+
+    var d = new DataWorker(dataset);
+    d.applyFilter(
+        {
+            columns          : [ "column_a", "column_c" ],
+            regex            : "^apple$",
+            accentInsensitive: true 
+        }
+    ).getRows(function (result) {
+        assert.deepEqual(result, [
+            [ "âpplé", "violin", "music" ],
+            [ "gummy", "power",  "apple" ]
+        ]);
+    }).finish(done);
+
+    d.applyFilter(
+        {
+            columns          : [ "column_a", "column_c" ],
+            regex            : "^applé$",
+            accentInsensitive: true 
+        }
+    ).getRows(function (result) {
+        assert.deepEqual(result, [
+            [ "âpplé", "violin", "music" ],
+            [ "gummy", "power",  "apple" ]
+        ]);
+    }).finish(done);
+});
+
+QUnit.test("apply filter (complex, single filter, multiple columns, accent sensitive)", function (assert) {
+    assert.expect(1);
+
+    var done = assert.async();
+
+    var dataset = [
+        [ "column_a", "column_b", "column_c" ],
+
+        [ "applé",      "violin",    "music" ],
+        [ "cat",        "tissue",      "dog" ],
+        [ undefined,        null,      "gum" ],
+        [ "gummy",       "power",    "apple" ]
+    ];
+
+    var d = new DataWorker(dataset);
+    d.applyFilter(
+        {
+            columns          : [ "column_a", "column_c" ],
+            regex            : "^apple$",
+            accentInsensitive: false 
+        }
+    ).getRows(function (result) {
+        assert.deepEqual(result, [
+            [ "gummy", "power",  "apple" ]
+        ]);
+    }).finish(done);
+
+    d.applyFilter(
+        {
+            columns          : [ "column_a", "column_c" ],
+            regex            : "^applé$",
+            accentInsensitive: false 
+        }
+    ).getRows(function (result) {
+        assert.deepEqual(result, [
+            [ "applé", "violin", "music" ],
+        ]);
+    }).finish(done);
+});
+
 QUnit.test("clear filter", function (assert) {
     assert.expect(1);
 

--- a/test/dw-local.js
+++ b/test/dw-local.js
@@ -542,7 +542,7 @@ QUnit.test("apply filter (complex, single filter, multiple columns)", function (
 });
 
 QUnit.test("apply filter (complex, single filter, multiple columns, accent insensitive)", function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     var done = assert.async();
 
@@ -567,7 +567,7 @@ QUnit.test("apply filter (complex, single filter, multiple columns, accent insen
             [ "âpplé", "violin", "music" ],
             [ "gummy", "power",  "apple" ]
         ]);
-    }).finish(done);
+    }).clearFilters();
 
     d.applyFilter(
         {
@@ -584,7 +584,7 @@ QUnit.test("apply filter (complex, single filter, multiple columns, accent insen
 });
 
 QUnit.test("apply filter (complex, single filter, multiple columns, accent sensitive)", function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     var done = assert.async();
 
@@ -608,7 +608,7 @@ QUnit.test("apply filter (complex, single filter, multiple columns, accent sensi
         assert.deepEqual(result, [
             [ "gummy", "power",  "apple" ]
         ]);
-    }).finish(done);
+    }).clearFilters();
 
     d.applyFilter(
         {


### PR DESCRIPTION
Add accentInsensitive option to allow user to filter records without concern to accented characters. This option is default to false so it doesn't affect any existing features. 
